### PR TITLE
Add RNN-based policy and training pipeline

### DIFF
--- a/policy/RNN_policy.py
+++ b/policy/RNN_policy.py
@@ -1,0 +1,72 @@
+import torch
+import pandas as pd
+
+from .base_policy import BasePolicy
+from .model import PriceRNN
+
+
+class RNNPolicy(BasePolicy):
+    """Policy using a pre-trained PriceRNN model.
+
+    When ``ts_len`` is ``None`` the policy keeps the LSTM hidden state between
+    calls, processing one new day at a time via :meth:`add_new_day_information`.
+    """
+
+    def __init__(self, model_path: str, ts_len: int | None = 30):
+        super().__init__()
+        self.ts_len = ts_len
+        self.model = PriceRNN()
+        state = torch.load(model_path, map_location="cpu")
+        self.model.load_state_dict(state)
+        self.model.eval()
+        self.hidden: tuple[torch.Tensor, torch.Tensor] | None = None
+        self._next_prob: float | None = None
+
+    # ============================================
+    #        - Redefined abstract methods -
+    # ============================================
+
+    def fit_method(self) -> int:  # pragma: no cover - no fitting required
+        return 0
+
+    def get_action(self, reference: pd.Series | None = None) -> int:
+        if self.ts_len is None:
+            # If no prediction has been computed yet (e.g. at start), run through
+            # all available history once to initialize hidden state.
+            if self._next_prob is None:
+                data = self.observation_hub.get_observations("all")
+                if len(data) == 0:
+                    return 0
+                x = torch.tensor(
+                    data[["open", "high", "low", "close"]].values,
+                    dtype=torch.float32,
+                ).unsqueeze(0)
+                with torch.no_grad():
+                    logits, _, self.hidden = self.model(x, self.hidden)
+                    self._next_prob = torch.softmax(logits, dim=-1)[0, 1].item()
+
+            prob = self._next_prob if self._next_prob is not None else 0.0
+            return 1 if prob > 0.5 else -1
+
+        data = self.observation_hub.get_observations(self.ts_len)
+        if len(data) < self.ts_len:
+            return 0  # not enough data
+        x = torch.tensor(
+            data[["open", "high", "low", "close"]].values, dtype=torch.float32
+        ).unsqueeze(0)
+        with torch.no_grad():
+            logits, _, _ = self.model(x)
+            prob = torch.softmax(logits, dim=-1)[0, 1].item()
+        return 1 if prob > 0.5 else -1
+
+    def add_new_day_information(self, reference: pd.Series) -> None:
+        self.observation_hub.add_observation(reference)
+        if self.ts_len is None:
+            x = torch.tensor(
+                reference[["open", "high", "low", "close"]].values,
+                dtype=torch.float32,
+            ).view(1, 1, 4)
+            with torch.no_grad():
+                logits, _, self.hidden = self.model(x, self.hidden)
+                self._next_prob = torch.softmax(logits, dim=-1)[0, 1].item()
+

--- a/policy/__init__.py
+++ b/policy/__init__.py
@@ -1,2 +1,5 @@
 from .base_policy import BasePolicy
 from .KNN_policy import KNNPolicy
+from .RNN_policy import RNNPolicy
+
+__all__ = ["BasePolicy", "KNNPolicy", "RNNPolicy"]

--- a/policy/model/__init__.py
+++ b/policy/model/__init__.py
@@ -1,0 +1,4 @@
+from .dataset import HugeStockMarketDataset
+from .rnn_model import PriceRNN
+
+__all__ = ["HugeStockMarketDataset", "PriceRNN"]

--- a/policy/model/dataset.py
+++ b/policy/model/dataset.py
@@ -1,0 +1,53 @@
+import os
+from pathlib import Path
+from typing import Tuple, Dict, Any
+
+import pandas as pd
+import torch
+from torch.utils.data import Dataset
+from tqdm import tqdm
+
+
+class HugeStockMarketDataset(Dataset):
+    """Dataset of OHLC sequences with next-day move labels.
+
+    Each sample contains a sequence of ``ts_len`` days with four features
+    (``Open``, ``High``, ``Low``, ``Close``).  The target is a binary label
+    indicating whether the closing price on the following day is above the
+    opening price.  Additionally, the raw price difference (close - open) is
+    returned for optional regression training.
+    """
+
+    def __init__(self, dataset_path: str, ts_len: int) -> None:
+        root = Path(dataset_path) / "Data" / "Stocks"
+        files = os.listdir(root)
+
+        self.objects = []
+        for f in tqdm(files[:100]):
+            try:
+                dt = pd.read_csv(os.path.join(root, f))["Open High Low Close".split()]
+
+                for i in range(len(dt) - ts_len - 1):
+                    end = dt.iloc[i + ts_len]
+                    delta = end["Close"] - end["Open"]
+                    self.objects.append(
+                        (
+                            dt.iloc[i : i + ts_len].to_numpy(),
+                            int(delta > 0),
+                            float(delta),
+                        )
+                    )
+            except Exception:
+                print(f"Problem in {f}")
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self.objects)
+
+    def __getitem__(self, idx: int) -> Dict[str, Any]:
+        dt = self.objects[idx]
+        return {
+            "data": torch.tensor(dt[0], dtype=torch.float32),
+            "class": torch.tensor(dt[1], dtype=torch.long),
+            "regr": torch.tensor(dt[2], dtype=torch.float32),
+        }
+

--- a/policy/model/rnn_model.py
+++ b/policy/model/rnn_model.py
@@ -1,0 +1,31 @@
+from typing import Optional, Tuple
+
+import torch
+from torch import nn
+
+
+class PriceRNN(nn.Module):
+    """Simple RNN model for sequence of OHLC prices."""
+
+    def __init__(self, input_size: int = 4, hidden_size: int = 64, num_layers: int = 2):
+        super().__init__()
+        self.rnn = nn.LSTM(
+            input_size=input_size,
+            hidden_size=hidden_size,
+            num_layers=num_layers,
+            batch_first=True,
+        )
+        self.classifier = nn.Linear(hidden_size, 2)
+        self.regressor = nn.Linear(hidden_size, 1)
+
+    def forward(
+        self, x: torch.Tensor, hidden: Optional[Tuple[torch.Tensor, torch.Tensor]] = None
+    ) -> Tuple[torch.Tensor, torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        """Run the LSTM and return class/regression heads and the new hidden state."""
+
+        out, hidden = self.rnn(x, hidden) if hidden is not None else self.rnn(x)
+        last = out[:, -1, :]
+        cls = self.classifier(last)
+        reg = self.regressor(last).squeeze(-1)
+        return cls, reg, hidden
+

--- a/policy/model/train_rnn.py
+++ b/policy/model/train_rnn.py
@@ -1,0 +1,69 @@
+"""Training script for the PriceRNN model.
+
+Example usage:
+    python policy/model/train_rnn.py --data /path/to/market --ts-len 30 --epochs 10
+"""
+
+import argparse
+from pathlib import Path
+
+import torch
+from torch import nn, optim
+from torch.utils.data import DataLoader
+
+
+def train(args: argparse.Namespace) -> None:
+    try:  # pragma: no cover - allow running as script or module
+        from .dataset import HugeStockMarketDataset
+        from .rnn_model import PriceRNN
+    except ImportError:  # pragma: no cover
+        from dataset import HugeStockMarketDataset
+        from rnn_model import PriceRNN
+
+    dataset = HugeStockMarketDataset(args.data, ts_len=args.ts_len)
+    loader = DataLoader(dataset, batch_size=args.batch_size, shuffle=True)
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = PriceRNN().to(device)
+    criterion_cls = nn.CrossEntropyLoss()
+    criterion_reg = nn.MSELoss()
+    optimizer = optim.Adam(model.parameters(), lr=args.lr)
+
+    for epoch in range(1, args.epochs + 1):
+        model.train()
+        total_loss = 0.0
+        for batch in loader:
+            x = batch["data"].to(device)
+            y_cls = batch["class"].to(device)
+            y_reg = batch["regr"].to(device)
+
+            optimizer.zero_grad()
+            pred_cls, pred_reg, _ = model(x)
+            loss = criterion_cls(pred_cls, y_cls) + criterion_reg(pred_reg, y_reg)
+            loss.backward()
+            optimizer.step()
+            total_loss += loss.item() * x.size(0)
+
+        avg_loss = total_loss / len(dataset)
+        print(f"Epoch {epoch}: loss={avg_loss:.4f}")
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    torch.save(model.state_dict(), output_path)
+    print(f"Model saved to {output_path}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Train PriceRNN policy")
+    parser.add_argument("--data", required=True, help="Path to dataset root")
+    parser.add_argument("--ts-len", type=int, default=30, help="Sequence length")
+    parser.add_argument("--batch-size", type=int, default=64, help="Training batch size")
+    parser.add_argument("--epochs", type=int, default=10, help="Number of training epochs")
+    parser.add_argument("--lr", type=float, default=1e-3, help="Learning rate")
+    parser.add_argument("--output", default="price_rnn.pt", help="Where to save trained weights")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    train(parse_args())
+


### PR DESCRIPTION
# Main implementations
- Adding RNN Policy along with HugeStock market dataset
- allow RNNPolicy to preserve hidden state when `ts_len` is `None` and update it with each new day
- make training script runnable as a module or script and adapt to new model API

# Testing
- `python -m py_compile policy/RNN_policy.py policy/model/dataset.py policy/model/rnn_model.py policy/model/train_rnn.py policy/__init__.py`
- `python policy/model/train_rnn.py --help`