### PR TITLE
Refactor A2C agent into configurable pipeline

### DIFF
--- a/conf/model/a2c_model.yaml
+++ b/conf/model/a2c_model.yaml
@@ -1,0 +1,4 @@
+defaults:
+  - backbone: cnn
+
+_target_: tensortrade.agents.a2c_agent.A2CAgent

--- a/conf/model/backbone/cnn.yaml
+++ b/conf/model/backbone/cnn.yaml
@@ -1,0 +1,1 @@
+_target_: pipelines.a2c_agent.models.cnn.CNNBackbone

--- a/conf/model/backbone/mlp.yaml
+++ b/conf/model/backbone/mlp.yaml
@@ -1,0 +1,1 @@
+_target_: pipelines.a2c_agent.models.mlp.MLPBackbone

--- a/conf/model/template_model.yaml
+++ b/conf/model/template_model.yaml
@@ -1,0 +1,7 @@
+# Template configuration for model creation
+# Select backbone: cnn or mlp
+
+defaults:
+  - backbone: cnn
+
+_target_: tensortrade.agents.a2c_agent.A2CAgent

--- a/conf/train/a2c_train.yaml
+++ b/conf/train/a2c_train.yaml
@@ -1,0 +1,4 @@
+defaults:
+  - approach: a2c
+
+_target_: pipelines.a2c_agent.train.a2c.A2CTrainer

--- a/conf/train/approach/a2c.yaml
+++ b/conf/train/approach/a2c.yaml
@@ -1,0 +1,14 @@
+_target_: pipelines.a2c_agent.train.a2c.A2CConfig
+batch_size: 128
+discount_factor: 0.9999
+learning_rate: 0.0001
+eps_start: 0.9
+eps_end: 0.05
+eps_decay_steps: 200
+entropy_c: 0.0001
+memory_capacity: 1000
+n_steps: null
+n_episodes: 1
+output_dir: runs/a2c
+checkpoint_every_steps: 1000
+resume_path: null

--- a/conf/train/approach/dpo.yaml
+++ b/conf/train/approach/dpo.yaml
@@ -1,0 +1,2 @@
+_target_: pipelines.a2c_agent.train.dpo.DPOConfig
+n_episodes: 1

--- a/conf/train/approach/ppo.yaml
+++ b/conf/train/approach/ppo.yaml
@@ -1,0 +1,16 @@
+_target_: pipelines.a2c_agent.train.ppo.PPOConfig
+batch_size: 2048
+mini_batch_size: 64
+epochs: 10
+gamma: 0.99
+lam: 0.95
+clip_range: 0.2
+learning_rate: 0.0003
+ent_coef: 0.0
+vf_coef: 0.5
+max_grad_norm: 0.5
+n_steps: null
+n_episodes: 1
+output_dir: runs/ppo
+checkpoint_every_steps: 1000
+resume_path: null

--- a/conf/train/ppo_train.yaml
+++ b/conf/train/ppo_train.yaml
@@ -1,0 +1,4 @@
+defaults:
+  - approach: ppo
+
+_target_: pipelines.a2c_agent.train.ppo.PPOTrainer

--- a/conf/train/template_train.yaml
+++ b/conf/train/template_train.yaml
@@ -1,0 +1,7 @@
+# Template training configuration
+# choose approach: a2c, dpo or ppo
+defaults:
+  - approach: a2c
+
+# Default trainer (can be overridden by approach)
+_target_: pipelines.a2c_agent.train.a2c.A2CTrainer

--- a/pipelines/a2c_agent/models/__init__.py
+++ b/pipelines/a2c_agent/models/__init__.py
@@ -1,0 +1,10 @@
+from .cnn import CNNBackbone
+from .mlp import MLPBackbone
+from .heads import ActorHead, CriticHead
+
+__all__ = [
+    "CNNBackbone",
+    "MLPBackbone",
+    "ActorHead",
+    "CriticHead",
+]

--- a/pipelines/a2c_agent/models/cnn.py
+++ b/pipelines/a2c_agent/models/cnn.py
@@ -1,0 +1,44 @@
+import torch
+import torch.nn as nn
+
+class CNNBackbone(nn.Module):
+    """Simple 1D convolutional backbone used by the A2C agent.
+
+    Parameters
+    ----------
+    input_shape: tuple
+        Shape of the observation without the batch dimension (C, L).
+    """
+
+    def __init__(self, input_shape: tuple):
+        super().__init__()
+        self.conv1 = nn.Conv1d(
+            in_channels=input_shape[0],
+            out_channels=64,
+            kernel_size=6,
+            padding="same",
+        )
+        self.conv2 = nn.Conv1d(
+            in_channels=64,
+            out_channels=32,
+            kernel_size=3,
+            padding="same",
+        )
+        self.pool = nn.MaxPool1d(kernel_size=2)
+        self.flatten = nn.Flatten()
+
+        with torch.no_grad():
+            dummy = torch.zeros(1, *input_shape)
+            x = self._forward_conv(dummy)
+            self.output_dim = x.shape[1]
+
+    def _forward_conv(self, x: torch.Tensor) -> torch.Tensor:
+        x = torch.tanh(self.conv1(x))
+        x = self.pool(x)
+        x = torch.tanh(self.conv2(x))
+        x = self.pool(x)
+        x = self.flatten(x)
+        return x
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self._forward_conv(x)

--- a/pipelines/a2c_agent/models/heads.py
+++ b/pipelines/a2c_agent/models/heads.py
@@ -1,0 +1,30 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+class ActorHead(nn.Module):
+    """MLP head that outputs action logits."""
+
+    def __init__(self, in_dim: int, n_actions: int):
+        super().__init__()
+        self.fc1 = nn.Linear(in_dim, 50)
+        self.fc2 = nn.Linear(50, n_actions)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = F.relu(self.fc1(x))
+        return self.fc2(x)
+
+
+class CriticHead(nn.Module):
+    """MLP head that predicts the state value."""
+
+    def __init__(self, in_dim: int):
+        super().__init__()
+        self.fc1 = nn.Linear(in_dim, 50)
+        self.fc2 = nn.Linear(50, 25)
+        self.fc3 = nn.Linear(25, 1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = F.relu(self.fc1(x))
+        x = F.relu(self.fc2(x))
+        return self.fc3(x)

--- a/pipelines/a2c_agent/models/mlp.py
+++ b/pipelines/a2c_agent/models/mlp.py
@@ -1,0 +1,19 @@
+import torch
+import torch.nn as nn
+
+class MLPBackbone(nn.Module):
+    """Fully connected backbone as an alternative to the CNN version."""
+
+    def __init__(self, input_shape: tuple):
+        super().__init__()
+        in_dim = input_shape[0] * input_shape[1]
+        self.flatten = nn.Flatten()
+        self.fc1 = nn.Linear(in_dim, 128)
+        self.fc2 = nn.Linear(128, 64)
+        self.output_dim = 64
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.flatten(x)
+        x = torch.relu(self.fc1(x))
+        x = torch.relu(self.fc2(x))
+        return x

--- a/pipelines/a2c_agent/train/__init__.py
+++ b/pipelines/a2c_agent/train/__init__.py
@@ -1,0 +1,12 @@
+from .a2c import A2CTrainer, A2CConfig
+from .dpo import DPOTrainer, DPOConfig
+from .ppo import PPOTrainer, PPOConfig
+
+__all__ = [
+    "A2CTrainer",
+    "A2CConfig",
+    "DPOTrainer",
+    "DPOConfig",
+    "PPOTrainer",
+    "PPOConfig",
+]

--- a/pipelines/a2c_agent/train/a2c.py
+++ b/pipelines/a2c_agent/train/a2c.py
@@ -1,0 +1,205 @@
+"""Training utilities for A2C agents."""
+
+from dataclasses import dataclass
+from typing import Optional
+from pathlib import Path
+import json
+import shutil
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from tensortrade.agents import ReplayMemory
+from tensortrade.agents.a2c_agent import A2CTransition
+
+
+@dataclass
+class A2CConfig:
+    """Configuration parameters for A2C training."""
+
+    batch_size: int = 128
+    discount_factor: float = 0.9999
+    learning_rate: float = 0.0001
+    eps_start: float = 0.9
+    eps_end: float = 0.05
+    eps_decay_steps: int = 200
+    entropy_c: float = 0.0001
+    memory_capacity: int = 1000
+    n_steps: Optional[int] = None
+    n_episodes: int = 1
+    output_dir: str = "runs/a2c"
+    checkpoint_every_steps: int = 1000
+    resume_path: Optional[str] = None
+
+
+class A2CTrainer:
+    """Simple trainer implementing the A2C algorithm with validation."""
+
+    def __init__(self, agent, train_env, valid_env, config: Optional[A2CConfig] = None):
+        self.agent = agent
+        self.train_env = train_env
+        self.valid_env = valid_env
+        self.cfg = config or A2CConfig()
+
+        self.output_dir = Path(self.cfg.output_dir)
+        self.ckpt_root = self.output_dir / "checkpoints"
+        self.ckpt_root.mkdir(parents=True, exist_ok=True)
+        self._start_episode = 0
+        self._start_step = 0
+
+        resume_path = self.cfg.resume_path
+        if resume_path:
+            self._load_checkpoint(resume_path)
+        elif (self.ckpt_root / "latest").exists():
+            self._load_checkpoint(self.ckpt_root / "latest")
+
+    # ------------------------------------------------------------------
+    # Core optimisation helpers (adapted from the original agent)
+    # ------------------------------------------------------------------
+    def _compute_returns(self, rewards, dones):
+        returns = []
+        G = 0.0
+        for r, d in zip(reversed(rewards), reversed(dones)):
+            G = r + self.cfg.discount_factor * G * (1 - int(d))
+            returns.append(G)
+        return torch.tensor(list(reversed(returns)), dtype=torch.float32, device=self.agent.device)
+
+    def _apply_gradient_descent(self, memory: ReplayMemory):
+        transitions = memory.tail(self.cfg.batch_size)
+        batch = A2CTransition(*zip(*transitions))
+
+        states = torch.tensor(np.stack(batch.state), dtype=torch.float32, device=self.agent.device)
+        if states.ndim == 3:
+            states = states.permute(0, 2, 1)
+
+        actions = torch.tensor(batch.action, dtype=torch.int64, device=self.agent.device)
+        rewards = torch.tensor(batch.reward, dtype=torch.float32, device=self.agent.device)
+        dones = torch.tensor(batch.done, dtype=torch.bool, device=self.agent.device)
+        values = torch.stack(batch.value).to(self.agent.device)
+
+        returns = self._compute_returns(rewards, dones)
+        advantages = returns - values.detach()
+
+        features = self.agent.shared_network(states)
+        logits = self.agent.actor_head(features)
+        new_values = self.agent.critic_head(features).squeeze(-1)
+
+        critic_loss = F.huber_loss(new_values, returns)
+        log_probs = F.log_softmax(logits, dim=-1)
+        selected_log_probs = log_probs.gather(1, actions.unsqueeze(1)).squeeze(1)
+        actor_loss = -(selected_log_probs * advantages).mean()
+        entropy = -(log_probs * torch.exp(log_probs)).sum(dim=-1).mean()
+        loss = actor_loss + 0.5 * critic_loss - self.cfg.entropy_c * entropy
+
+        self.agent.optimizer.zero_grad()
+        loss.backward()
+        nn.utils.clip_grad_norm_(
+            list(self.agent.shared_network.parameters())
+            + list(self.agent.actor_head.parameters())
+            + list(self.agent.critic_head.parameters()),
+            max_norm=0.5,
+        )
+        self.agent.optimizer.step()
+
+    # ------------------------------------------------------------------
+    def _save_checkpoint(self, step: int, episode: int):
+        ckpt_dir = self.ckpt_root / str(step)
+        model_dir = ckpt_dir / "model"
+        trainer_dir = ckpt_dir / "trainer"
+        model_dir.mkdir(parents=True, exist_ok=True)
+        trainer_dir.mkdir(parents=True, exist_ok=True)
+
+        torch.save(
+            {
+                "shared": self.agent.shared_network.state_dict(),
+                "actor": self.agent.actor_head.state_dict(),
+                "critic": self.agent.critic_head.state_dict(),
+            },
+            model_dir / "state.pt",
+        )
+        torch.save(self.agent.optimizer.state_dict(), trainer_dir / "optimizer.pt")
+        if hasattr(self.agent, "scheduler"):
+            torch.save(self.agent.scheduler.state_dict(), trainer_dir / "scheduler.pt")
+        with open(ckpt_dir / "meta.json", "w") as f:
+            json.dump({"step": step, "episode": episode}, f)
+
+        latest_dir = self.ckpt_root / "latest"
+        if latest_dir.exists():
+            shutil.rmtree(latest_dir)
+        shutil.copytree(ckpt_dir, latest_dir)
+
+    def _load_checkpoint(self, path):
+        ckpt_dir = Path(path)
+        model_state = torch.load(ckpt_dir / "model" / "state.pt", map_location=self.agent.device)
+        self.agent.shared_network.load_state_dict(model_state["shared"])
+        self.agent.actor_head.load_state_dict(model_state["actor"])
+        self.agent.critic_head.load_state_dict(model_state["critic"])
+        opt_state = torch.load(ckpt_dir / "trainer" / "optimizer.pt", map_location=self.agent.device)
+        self.agent.optimizer.load_state_dict(opt_state)
+        sched_path = ckpt_dir / "trainer" / "scheduler.pt"
+        if hasattr(self.agent, "scheduler") and sched_path.exists():
+            self.agent.scheduler.load_state_dict(torch.load(sched_path, map_location=self.agent.device))
+        meta_path = ckpt_dir / "meta.json"
+        if meta_path.exists():
+            with open(meta_path) as f:
+                meta = json.load(f)
+            self._start_step = meta.get("step", 0)
+            self._start_episode = meta.get("episode", 0)
+
+    def train(self):
+        cfg = self.cfg
+        # update learning rate
+        for pg in self.agent.optimizer.param_groups:
+            pg["lr"] = cfg.learning_rate
+
+        memory = ReplayMemory(cfg.memory_capacity, transition_type=A2CTransition)
+        episode = self._start_episode
+        steps_done = self._start_step
+        if cfg.n_steps and not cfg.n_episodes:
+            cfg.n_episodes = np.iinfo(np.int32).max
+
+        while episode < cfg.n_episodes:
+            state = self.train_env.reset()
+            done = False
+            while not done:
+                threshold = cfg.eps_end + (cfg.eps_start - cfg.eps_end) * np.exp(
+                    -steps_done / cfg.eps_decay_steps
+                )
+                action = self.agent.get_action(state, threshold=threshold)
+                next_state, reward, done, _ = self.train_env.step(action)
+
+                with torch.no_grad():
+                    _, value = self.agent._infer(state)
+                memory.push(state, action, reward, done, value)
+
+                state = next_state
+                steps_done += 1
+
+                if len(memory) >= cfg.batch_size:
+                    self._apply_gradient_descent(memory)
+
+                if (
+                    cfg.checkpoint_every_steps
+                    and steps_done % cfg.checkpoint_every_steps == 0
+                ):
+                    self._save_checkpoint(steps_done, episode)
+
+                if cfg.n_steps and steps_done >= cfg.n_steps:
+                    done = True
+            # run validation once per episode
+            self._validate()
+            episode += 1
+
+        self._save_checkpoint(steps_done, episode)
+
+    def _validate(self):
+        state = self.valid_env.reset()
+        done = False
+        total_reward = 0.0
+        while not done:
+            action = self.agent.get_action(state)
+            state, reward, done, _ = self.valid_env.step(action)
+            total_reward += reward
+        print(f"Validation reward: {total_reward:.4f}")

--- a/pipelines/a2c_agent/train/dpo.py
+++ b/pipelines/a2c_agent/train/dpo.py
@@ -1,0 +1,42 @@
+"""Skeleton of a Direct Preference Optimisation trainer.
+
+The implementation here is intentionally lightweight and serves as a
+placeholder for more sophisticated preference‑based learning methods.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class DPOConfig:
+    """Configuration for DPO training."""
+
+    n_episodes: int = 1
+
+
+class DPOTrainer:
+    """Minimal trainer demonstrating the required interface."""
+
+    def __init__(self, agent, train_env, valid_env, config: Optional[DPOConfig] = None):
+        self.agent = agent
+        self.train_env = train_env
+        self.valid_env = valid_env
+        self.cfg = config or DPOConfig()
+
+    def train(self):
+        """Run preference‑based optimisation.
+
+        The full algorithm is outside the scope of this repository; the method
+        simply iterates over the validation environment to showcase the
+        interface.
+        """
+        for _ in range(self.cfg.n_episodes):
+            state = self.valid_env.reset()
+            done = False
+            total_reward = 0.0
+            while not done:
+                action = self.agent.get_action(state)
+                state, reward, done, _ = self.valid_env.step(action)
+                total_reward += reward
+            print(f"DPO validation reward: {total_reward:.4f}")

--- a/pipelines/a2c_agent/train/ppo.py
+++ b/pipelines/a2c_agent/train/ppo.py
@@ -1,0 +1,264 @@
+"""Training utilities for PPO agents."""
+
+from dataclasses import dataclass
+from typing import Optional, List
+from pathlib import Path
+import json
+import shutil
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from tensortrade.agents.a2c_agent import A2CTransition  # for type reference
+
+
+@dataclass
+class PPOConfig:
+    """Configuration parameters for PPO training."""
+
+    batch_size: int = 2048  # number of timesteps per rollout
+    mini_batch_size: int = 64
+    epochs: int = 10
+    gamma: float = 0.99
+    lam: float = 0.95
+    clip_range: float = 0.2
+    learning_rate: float = 3e-4
+    ent_coef: float = 0.0
+    vf_coef: float = 0.5
+    max_grad_norm: float = 0.5
+    n_steps: Optional[int] = None
+    n_episodes: int = 1
+    output_dir: str = "runs/ppo"
+    checkpoint_every_steps: int = 1000
+    resume_path: Optional[str] = None
+
+
+class RolloutBuffer:
+    """Simple buffer to collect rollouts for PPO."""
+
+    def __init__(self):
+        self.states: List[np.ndarray] = []
+        self.actions: List[int] = []
+        self.log_probs: List[float] = []
+        self.rewards: List[float] = []
+        self.dones: List[bool] = []
+        self.values: List[float] = []
+
+    def add(self, state, action, log_prob, reward, done, value):
+        self.states.append(state)
+        self.actions.append(action)
+        self.log_probs.append(log_prob)
+        self.rewards.append(reward)
+        self.dones.append(done)
+        self.values.append(value)
+
+    def clear(self):
+        self.__init__()
+
+    def __len__(self):
+        return len(self.states)
+
+
+class PPOTrainer:
+    """Trainer implementing the PPO algorithm with validation."""
+
+    def __init__(self, agent, train_env, valid_env, config: Optional[PPOConfig] = None):
+        self.agent = agent
+        self.train_env = train_env
+        self.valid_env = valid_env
+        self.cfg = config or PPOConfig()
+
+        self.output_dir = Path(self.cfg.output_dir)
+        self.ckpt_root = self.output_dir / "checkpoints"
+        self.ckpt_root.mkdir(parents=True, exist_ok=True)
+        self._start_episode = 0
+        self._start_step = 0
+
+        resume_path = self.cfg.resume_path
+        if resume_path:
+            self._load_checkpoint(resume_path)
+        elif (self.ckpt_root / "latest").exists():
+            self._load_checkpoint(self.ckpt_root / "latest")
+
+    # ------------------------------------------------------------------
+    def _compute_gae(self, rewards, dones, values, last_value):
+        cfg = self.cfg
+        values = np.append(values, last_value)
+        gae = 0.0
+        advantages = np.zeros_like(rewards, dtype=np.float32)
+        for t in reversed(range(len(rewards))):
+            delta = rewards[t] + cfg.gamma * values[t + 1] * (1 - dones[t]) - values[t]
+            gae = delta + cfg.gamma * cfg.lam * (1 - dones[t]) * gae
+            advantages[t] = gae
+        returns = advantages + values[:-1]
+        return advantages, returns
+
+    def _update(self, buffer: RolloutBuffer, last_value: float):
+        cfg = self.cfg
+        states = torch.tensor(np.stack(buffer.states), dtype=torch.float32, device=self.agent.device)
+        if states.ndim == 3:
+            states = states.permute(0, 2, 1)
+        actions = torch.tensor(buffer.actions, dtype=torch.int64, device=self.agent.device)
+        old_log_probs = torch.tensor(buffer.log_probs, dtype=torch.float32, device=self.agent.device)
+        rewards = np.array(buffer.rewards, dtype=np.float32)
+        dones = np.array(buffer.dones, dtype=np.bool_)
+        values = np.array(buffer.values, dtype=np.float32)
+        advantages, returns = self._compute_gae(rewards, dones, values, last_value)
+        advantages = torch.tensor(advantages, dtype=torch.float32, device=self.agent.device)
+        returns = torch.tensor(returns, dtype=torch.float32, device=self.agent.device)
+        advantages = (advantages - advantages.mean()) / (advantages.std() + 1e-8)
+
+        batch_size = len(buffer)
+        inds = np.arange(batch_size)
+        for _ in range(cfg.epochs):
+            np.random.shuffle(inds)
+            for start in range(0, batch_size, cfg.mini_batch_size):
+                end = start + cfg.mini_batch_size
+                mb_inds = inds[start:end]
+
+                mb_states = states[mb_inds]
+                mb_actions = actions[mb_inds]
+                mb_old_log_probs = old_log_probs[mb_inds]
+                mb_advantages = advantages[mb_inds]
+                mb_returns = returns[mb_inds]
+
+                features = self.agent.shared_network(mb_states)
+                logits = self.agent.actor_head(features)
+                new_values = self.agent.critic_head(features).squeeze(-1)
+                dist = torch.distributions.Categorical(logits=logits)
+                new_log_probs = dist.log_prob(mb_actions)
+                entropy = dist.entropy().mean()
+
+                ratio = torch.exp(new_log_probs - mb_old_log_probs)
+                surr1 = ratio * mb_advantages
+                surr2 = torch.clamp(ratio, 1.0 - cfg.clip_range, 1.0 + cfg.clip_range) * mb_advantages
+                actor_loss = -torch.min(surr1, surr2).mean()
+
+                critic_loss = F.mse_loss(new_values, mb_returns)
+
+                loss = actor_loss + cfg.vf_coef * critic_loss - cfg.ent_coef * entropy
+
+                self.agent.optimizer.zero_grad()
+                loss.backward()
+                nn.utils.clip_grad_norm_(
+                    list(self.agent.shared_network.parameters())
+                    + list(self.agent.actor_head.parameters())
+                    + list(self.agent.critic_head.parameters()),
+                    cfg.max_grad_norm,
+                )
+                self.agent.optimizer.step()
+
+    # ------------------------------------------------------------------
+    def _save_checkpoint(self, step: int, episode: int):
+        ckpt_dir = self.ckpt_root / str(step)
+        model_dir = ckpt_dir / "model"
+        trainer_dir = ckpt_dir / "trainer"
+        model_dir.mkdir(parents=True, exist_ok=True)
+        trainer_dir.mkdir(parents=True, exist_ok=True)
+
+        torch.save(
+            {
+                "shared": self.agent.shared_network.state_dict(),
+                "actor": self.agent.actor_head.state_dict(),
+                "critic": self.agent.critic_head.state_dict(),
+            },
+            model_dir / "state.pt",
+        )
+        torch.save(self.agent.optimizer.state_dict(), trainer_dir / "optimizer.pt")
+        if hasattr(self.agent, "scheduler"):
+            torch.save(self.agent.scheduler.state_dict(), trainer_dir / "scheduler.pt")
+        with open(ckpt_dir / "meta.json", "w") as f:
+            json.dump({"step": step, "episode": episode}, f)
+
+        latest_dir = self.ckpt_root / "latest"
+        if latest_dir.exists():
+            shutil.rmtree(latest_dir)
+        shutil.copytree(ckpt_dir, latest_dir)
+
+    def _load_checkpoint(self, path):
+        ckpt_dir = Path(path)
+        model_state = torch.load(ckpt_dir / "model" / "state.pt", map_location=self.agent.device)
+        self.agent.shared_network.load_state_dict(model_state["shared"])
+        self.agent.actor_head.load_state_dict(model_state["actor"])
+        self.agent.critic_head.load_state_dict(model_state["critic"])
+        opt_state = torch.load(ckpt_dir / "trainer" / "optimizer.pt", map_location=self.agent.device)
+        self.agent.optimizer.load_state_dict(opt_state)
+        sched_path = ckpt_dir / "trainer" / "scheduler.pt"
+        if hasattr(self.agent, "scheduler") and sched_path.exists():
+            self.agent.scheduler.load_state_dict(torch.load(sched_path, map_location=self.agent.device))
+        meta_path = ckpt_dir / "meta.json"
+        if meta_path.exists():
+            with open(meta_path) as f:
+                meta = json.load(f)
+            self._start_step = meta.get("step", 0)
+            self._start_episode = meta.get("episode", 0)
+
+    def train(self):
+        cfg = self.cfg
+        for pg in self.agent.optimizer.param_groups:
+            pg["lr"] = cfg.learning_rate
+
+        buffer = RolloutBuffer()
+        episode = self._start_episode
+        total_steps = self._start_step
+        if cfg.n_steps and not cfg.n_episodes:
+            cfg.n_episodes = np.iinfo(np.int32).max
+
+        state = self.train_env.reset()
+        done = False
+        episode_steps = 0
+        while episode < cfg.n_episodes:
+            logits, value = self.agent._infer(state)
+            dist = torch.distributions.Categorical(logits=logits)
+            action = dist.sample()
+            log_prob = dist.log_prob(action).item()
+            next_state, reward, done, _ = self.train_env.step(action.item())
+
+            buffer.add(state, action.item(), log_prob, reward, done, value.item())
+
+            state = next_state
+            total_steps += 1
+            episode_steps += 1
+
+            if len(buffer) >= cfg.batch_size:
+                with torch.no_grad():
+                    last_value = 0.0 if done else self.agent._infer(state)[1].item()
+                self._update(buffer, last_value)
+                buffer.clear()
+
+            if (
+                cfg.checkpoint_every_steps
+                and total_steps % cfg.checkpoint_every_steps == 0
+            ):
+                with torch.no_grad():
+                    last_value = 0.0 if done else self.agent._infer(state)[1].item()
+                if len(buffer) > 0:
+                    self._update(buffer, last_value)
+                    buffer.clear()
+                self._save_checkpoint(total_steps, episode)
+
+            if done or (cfg.n_steps and episode_steps >= cfg.n_steps):
+                with torch.no_grad():
+                    last_value = 0.0 if done else self.agent._infer(state)[1].item()
+                if len(buffer) > 0:
+                    self._update(buffer, last_value)
+                    buffer.clear()
+                self._validate()
+                state = self.train_env.reset()
+                done = False
+                episode += 1
+                episode_steps = 0
+
+        self._save_checkpoint(total_steps, episode)
+
+    def _validate(self):
+        state = self.valid_env.reset()
+        done = False
+        total_reward = 0.0
+        while not done:
+            action = self.agent.get_action(state)
+            state, reward, done, _ = self.valid_env.step(action)
+            total_reward += reward
+        print(f"Validation reward: {total_reward:.4f}")

--- a/tensortrade/agents/a2c_agent.py
+++ b/tensortrade/agents/a2c_agent.py
@@ -31,91 +31,12 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
 
-from tensortrade.agents import Agent, ReplayMemory
+from tensortrade.agents import Agent
+from pipelines.a2c_agent.models import CNNBackbone, ActorHead, CriticHead
 
 A2CTransition = namedtuple(
     "A2CTransition", ["state", "action", "reward", "done", "value"]
 )
-
-
-# ────────────────────────────────────────────────────────────────────────────────
-# Helper networks
-# ────────────────────────────────────────────────────────────────────────────────
-
-
-class SharedNet(nn.Module):
-    """
-    Convolutional feature extractor shared by both actor and critic.
-    """
-
-    def __init__(self, input_shape: tuple):
-        """
-        Args:
-            input_shape: Shape of observation without batch dimension
-                         (C, L) for Conv1D.
-        """
-        super().__init__()
-        self.conv1 = nn.Conv1d(
-            in_channels=input_shape[0],
-            out_channels=64,
-            kernel_size=6,
-            padding="same",
-        )
-        self.conv2 = nn.Conv1d(
-            in_channels=64,
-            out_channels=32,
-            kernel_size=3,
-            padding="same",
-        )
-        self.pool = nn.MaxPool1d(kernel_size=2)
-        self.flatten = nn.Flatten()
-
-        # Determine the size of the flattened feature vector dynamically.
-        with torch.no_grad():
-            dummy = torch.zeros(1, *input_shape)
-            x = self._forward_conv(dummy)
-            self.output_dim = x.shape[1]
-
-    def _forward_conv(self, x: torch.Tensor) -> torch.Tensor:
-        x = torch.tanh(self.conv1(x))
-        x = self.pool(x)
-        x = torch.tanh(self.conv2(x))
-        x = self.pool(x)
-        x = self.flatten(x)
-        return x
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:  # noqa: D401
-        """
-        Forward pass through shared conv layers.
-
-        Args:
-            x: Tensor with shape (B, C, L)
-        """
-        return self._forward_conv(x)
-
-
-class ActorHead(nn.Module):
-    def __init__(self, in_dim: int, n_actions: int):
-        super().__init__()
-        self.fc1 = nn.Linear(in_dim, 50)
-        self.fc2 = nn.Linear(50, n_actions)
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        x = F.relu(self.fc1(x))
-        return self.fc2(x)  # raw logits
-
-
-class CriticHead(nn.Module):
-    def __init__(self, in_dim: int):
-        super().__init__()
-        self.fc1 = nn.Linear(in_dim, 50)
-        self.fc2 = nn.Linear(50, 25)
-        self.fc3 = nn.Linear(25, 1)
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        x = F.relu(self.fc1(x))
-        x = F.relu(self.fc2(x))
-        return self.fc3(x)  # state‑value estimate
 
 
 # ────────────────────────────────────────────────────────────────────────────────
@@ -144,13 +65,15 @@ class A2CAgent(Agent):
         self.env = env
         self.n_actions = env.action_space.n
         # Convert TF style (L, C) to PyTorch (C, L) for Conv1d.
-        self.observation_shape = (env.observation_space.shape[1], env.observation_space.shape[0])  # (C, L)
+        self.observation_shape = (
+            env.observation_space.shape[1],
+            env.observation_space.shape[0],
+        )  # (C, L)
         self.device = torch.device(device or ("cuda" if torch.cuda.is_available() else "cpu"))
 
         # Networks
-        self.shared_network = (shared_network or SharedNet(self.observation_shape)).to(
-            self.device
-        )
+        backbone = shared_network or CNNBackbone(self.observation_shape)
+        self.shared_network = backbone.to(self.device)
         if actor_network and critic_network:
             self.actor_head = actor_network.to(self.device)
             self.critic_head = critic_network.to(self.device)
@@ -228,154 +151,5 @@ class A2CAgent(Agent):
         dist = torch.distributions.Categorical(probs)
         return dist.sample().item()
 
-    # ────────────────────────────────────────────────────────────────────────
-    # Training helpers
-    # ────────────────────────────────────────────────────────────────────────
-
-    def _compute_returns(self, rewards, dones, discount_factor):
-        """
-        Compute discounted returns in reverse (vectorized).
-        """
-        returns = []
-        G = 0.0
-        for r, d in zip(reversed(rewards), reversed(dones)):
-            G = r + discount_factor * G * (1 - int(d))
-            returns.append(G)
-        return torch.tensor(list(reversed(returns)), dtype=torch.float32, device=self.device)
-
-    def _apply_gradient_descent(
-        self,
-        memory: ReplayMemory,
-        batch_size: int,
-        learning_rate: float,
-        discount_factor: float,
-        entropy_c: float,
-    ):
-        transitions = memory.tail(batch_size)
-        batch = A2CTransition(*zip(*transitions))
-
-        states = torch.tensor(np.stack(batch.state), dtype=torch.float32, device=self.device)
-        if states.ndim == 3:  # (B, L, C) -> (B, C, L)
-            states = states.permute(0, 2, 1)
-
-        actions = torch.tensor(batch.action, dtype=torch.int64, device=self.device)
-        rewards = torch.tensor(batch.reward, dtype=torch.float32, device=self.device)
-        dones = torch.tensor(batch.done, dtype=torch.bool, device=self.device)
-        values = torch.stack(batch.value).to(self.device)
-
-        returns = self._compute_returns(rewards, dones, discount_factor)
-        advantages = returns - values.detach()
-
-        # Forward pass
-        features = self.shared_network(states)
-        logits = self.actor_head(features)
-        new_values = self.critic_head(features).squeeze(-1)
-
-        # Critic loss (Huber)
-        critic_loss = F.huber_loss(new_values, returns)
-
-        # Actor loss (policy gradient with advantage weighting)
-        log_probs = F.log_softmax(logits, dim=-1)
-        selected_log_probs = log_probs.gather(1, actions.unsqueeze(1)).squeeze(1)
-        actor_loss = -(selected_log_probs * advantages).mean()
-
-        # Entropy regularization
-        entropy = -(log_probs * torch.exp(log_probs)).sum(dim=-1).mean()
-        loss = actor_loss + 0.5 * critic_loss - entropy_c * entropy
-
-        # Optimise
-        self.optimizer.zero_grad()
-        loss.backward()
-        nn.utils.clip_grad_norm_(
-            list(self.shared_network.parameters())
-            + list(self.actor_head.parameters())
-            + list(self.critic_head.parameters()),
-            max_norm=0.5,
-        )
-        self.optimizer.step()
-
-    # ────────────────────────────────────────────────────────────────────────
-    # Training loop
-    # ────────────────────────────────────────────────────────────────────────
-
-    def train(
-        self,
-        n_steps: int = None,
-        n_episodes: int = None,
-        save_every: int = None,
-        save_path: str = None,
-        callback: callable = None,
-        **kwargs,
-    ) -> float:
-        batch_size: int = kwargs.get("batch_size", 128)
-        discount_factor: float = kwargs.get("discount_factor", 0.9999)
-        learning_rate: float = kwargs.get("learning_rate", 0.0001)
-        eps_start: float = kwargs.get("eps_start", 0.9)
-        eps_end: float = kwargs.get("eps_end", 0.05)
-        eps_decay_steps: int = kwargs.get("eps_decay_steps", 200)
-        entropy_c: float = kwargs.get("entropy_c", 0.0001)
-        memory_capacity: int = kwargs.get("memory_capacity", 1000)
-
-        # update learning rate if provided (allows runtime adjustment)
-        for pg in self.optimizer.param_groups:
-            pg["lr"] = learning_rate
-
-        memory = ReplayMemory(memory_capacity, transition_type=A2CTransition)
-        episode = 0
-        steps_done = 0
-        total_reward = 0.0
-        stop_training = False
-
-        if n_steps and not n_episodes:
-            n_episodes = np.iinfo(np.int32).max
-
-        print(f"====      AGENT ID: {self.id}      ====")
-
-        while episode < n_episodes and not stop_training:
-            state = self.env.reset()
-            done = False
-
-            print(
-                f"====      EPISODE ID ({episode + 1}/{n_episodes}): {self.env.episode_id}      ===="
-            )
-
-            while not done:
-                threshold = eps_end + (eps_start - eps_end) * np.exp(
-                    -steps_done / eps_decay_steps
-                )
-                action = self.get_action(state, threshold=threshold)
-                next_state, reward, done, _ = self.env.step(action)
-
-                # Compute value of current state for advantage
-                with torch.no_grad():
-                    _, value = self._infer(state)
-
-                memory.push(state, action, reward, done, value)
-
-                state = next_state
-                total_reward += reward
-                steps_done += 1
-
-                if len(memory) < batch_size:
-                    continue
-
-                self._apply_gradient_descent(
-                    memory,
-                    batch_size,
-                    learning_rate,
-                    discount_factor,
-                    entropy_c,
-                )
-
-                if n_steps and steps_done >= n_steps:
-                    done = True
-                    stop_training = True
-
-            is_checkpoint = save_every and episode % save_every == 0
-            if save_path and (is_checkpoint or episode + 1 == n_episodes):
-                self.save(save_path, episode=episode)
-
-            episode += 1
-
-        mean_reward = total_reward / max(1, steps_done)
-        return mean_reward
+    # Training utilities removed. Training is now handled by dedicated
+    # trainer classes located under ``pipelines.a2c_agent.train``.


### PR DESCRIPTION
## Summary
- add step-based checkpointing with restart support to A2C and PPO trainers
- initialize training output directories and maintain latest checkpoint snapshot
- expose checkpoint interval and resume path through Hydra training configs

## Testing
- `pytest tests/tensortrade/unit -q` *(fails: FileNotFoundError: 'tests/data/input/bitfinex_(BTC,ETH)USD_d.csv' and AttributeError: 'TestTensorTradeRewardScheme' object has no attribute 'config')*

------
https://chatgpt.com/codex/tasks/task_e_68c334626ff88327925b1570df2444f2